### PR TITLE
Remove unused `hiredis`

### DIFF
--- a/lib/litestack/litesupport.rb
+++ b/lib/litestack/litesupport.rb
@@ -1,5 +1,4 @@
 require 'sqlite3'
-require 'hiredis'
 
 module Litesupport
 


### PR DESCRIPTION
Attempts to fix https://github.com/oldmoe/litestack/issues/3

It may be that you instead wish to move `hiredis` into a dev dependency, and include it in `bench.rb` instead. I wasn't sure if `hiredis` aliases the `Redis` constant that is otherwise used, so I wasn't sure if was actually the correct dependency.