### PR TITLE
Check if `Rails::Railtie` is defined before requiring `litestack/railtie`

### DIFF
--- a/lib/litestack.rb
+++ b/lib/litestack.rb
@@ -16,7 +16,7 @@ require_relative "./railties/rails/commands/dbconsole" if defined? Rails && defi
 require_relative "./active_support/cache/litecache" if defined? ActiveSupport
 require_relative "./active_job/queue_adapters/litejob_adapter" if defined? ActiveJob
 require_relative "./action_cable/subscription_adapter/litecable" if defined? ActionCable
-require_relative "./litestack/railtie" if defined? Rails
+require_relative "./litestack/railtie" if defined? Rails::Railtie
 
 module Litestack
   class NotImplementedError < Exception; end


### PR DESCRIPTION
Hey, thanks for putting this super promising project on!

I was running `litestack` in the context of a gem, which doesn't have a dependency on `Rails` and/or `Rails::Railtie`. 

It seems that the `Rails` constant is still present in the gem context which leads to requiring the `litestack/railtie` file. That require fails since `Rails::Railtie` is not defined.

This pull request updates the `defined?` call to check if `Rails::Railtie` is defined instead, which removes the need for the `railtie` dependency proposed in #16. 