### PR TITLE
Fix SQLite3 deprecation warning

### DIFF
--- a/lib/litestack/litesupport.rb
+++ b/lib/litestack/litesupport.rb
@@ -312,7 +312,7 @@ module Litesupport
     end
 
     def run_sql(sql, *args)
-      @conn.acquire{|q| q.execute(sql, *args) }
+      @conn.acquire { |q| q.execute(sql, args) }
     end
     
     def run_method(method, *args)


### PR DESCRIPTION
I see this a lot in my logs:
```
litestack/lib/litestack/litesupport.rb:315:in `block in run_sql' is calling SQLite3::Database#execute with nil or multiple bind params without using an array.  Please switch to passing bind parameters as an array.
Support for bind parameters as *args will be removed in 2.0.0.
```