### PR TITLE
Ignore dev dbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/development/*.sqlite3*


### PR DESCRIPTION
Does what it says on the tin — adds to .gitignore the glob pattern for the database files created by the components