### PR TITLE
Fix condition for loading Rails DBConsole

### DIFF
--- a/lib/litestack.rb
+++ b/lib/litestack.rb
@@ -13,7 +13,7 @@ require_relative "./litestack/litecable"
 # conditionally load integration with other libraries
 require_relative "./sequel/adapters/litedb" if defined? Sequel
 require_relative "./active_record/connection_adapters/litedb_adapter" if defined? ActiveRecord
-require_relative "./railties/rails/commands/dbconsole" if defined? Rails && defined? ActiveRecord
+require_relative "./railties/rails/commands/dbconsole" if defined?(Rails) && defined?(ActiveRecord)
 require_relative "./active_support/cache/litecache" if defined? ActiveSupport
 require_relative "./active_job/queue_adapters/litejob_adapter" if defined? ActiveJob
 require_relative "./action_cable/subscription_adapter/litecable" if defined? ActionCable


### PR DESCRIPTION
The code in the condition always evaluates to true, because
```
if defined? Rails && defined? ActiveRecord
```
is equivalent to
```
if defined?(Rails && defined? ActiveRecord)
```
which is always true, because the code inside parentheses is an `expression`. This results in the file getting required anyway.