### PR TITLE
Litecable must invoke success_callback on #subscribe

### DIFF
--- a/lib/litestack/litecable.rb
+++ b/lib/litestack/litecable.rb
@@ -44,6 +44,7 @@ class Litecable
       subs[channel] = {} unless subs[channel]
       subs[channel][subscriber] = true
     end
+    success_callback&.call
     capture(:subscribe, channel)
   end
   


### PR DESCRIPTION
Without invoking success_callback, subscription confirmation is never sent to the client: https://github.com/rails/rails/blob/main/actioncable/lib/action_cable/channel/streams.rb#L91

Offtopic: why not using Rails' [SubscriberMap](https://github.com/rails/rails/blob/main/actioncable/lib/action_cable/subscription_adapter/subscriber_map.rb) to maintain subscribers and perform local broadcasts? I think, it could simplify the implantation (and prevent from such incompatibilities, too).