### PR TITLE
Update template.rb to published litestack gem

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -1,6 +1,6 @@
-# Run `rails new my-app -m https://raw.githubusercontent.com/bradgessler/litestack/master/template.rb`
+# Run `rails new my-app -m https://raw.githubusercontent.com/oldmoe/litestack/master/template.rb`
 # to create a new Rails app with Litestack pre-installed.
-gem "litestack", github: "bradgessler/litestack"
+gem "litestack", github: "litestack"
 
 after_bundle do
   generate "litestack:install"


### PR DESCRIPTION
Update template.rb to use the litestack rubygem published at rubygem.org.

Before this change, a new rails app generated from template.rb uses the master branch of @bradgessler 's fork of litestack.

```
$ rails new my-app -m https://raw.githubusercontent.com/oldmoe/litestack/master/template.rb
[...]
$ grep litestack my-app/Gemfile*
my-app/Gemfile:gem "litestack", github: "bradgessler/litestack"
my-app/Gemfile.lock:  remote: https://github.com/bradgessler/litestack.git
my-app/Gemfile.lock:    litestack (0.2.3)
my-app/Gemfile.lock:  litestack!
```

After this change, a new rails app generated from template.rb uses the latest litestack rubygem version.

```
$ rails new my-app -m https://raw.githubusercontent.com/oldmoe/litestack/master/template.rb
$ grep litestack my-app/Gemfile*
my-app/Gemfile:gem "litestack"
my-app/Gemfile.lock:    litestack (0.4.1)
my-app/Gemfile.lock:  litestack
```