### PR TITLE
Add diff links to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- [View Diff](https://github.com/oldmoe/litestack/compare/v0.4.1...master)
 - Add similarity search support for Litesearch
 - Enable similarity search for ActiveRecord and Sequel models
 - Fix Litesearch tests
@@ -8,16 +9,19 @@
 
 ## [0.4.1] - 2023-10-11
 
+- [View Diff](https://github.com/oldmoe/litestack/compare/v0.4.0...v0.4.1)
 - Add missing Litesearch::Model dependency
 
 ## [0.4.0] - 2023-10-11
 
+- [View Diff](https://github.com/oldmoe/litestack/compare/v0.3.0...v0.4.0)
 - Introduced Litesearch, dynamic & fast full text search capability for Litedb
 - ActiveRecord and Sequel integration for Litesearch
 - Slight improvement to the Sequel Litedb adapter for better Litesearch integration
 
 ## [0.3.0] - 2023-08-13
 
+- [View Diff](https://github.com/oldmoe/litestack/compare/v0.2.6...v0.3.0)
 - Reworked the Litecable thread safety model
 - Fixed multiple litejob bugs (thanks Stephen Margheim)
 - Fixed Railtie dependency (thanks Marco Roth)
@@ -27,6 +31,7 @@
 
 ## [0.2.6] - 2023-07-16
 
+- [View Diff](https://github.com/oldmoe/litestack/compare/v0.2.3...v0.2.6)
 - Much improved database location setting (thanks Brad Gessler)
 - A Rails generator for better Rails Litestack defaults (thanks Brad Gessler)
 - Revamped Litemetric, now much faster and more accurate (still experimental)
@@ -34,19 +39,23 @@
 
 ## [0.2.3] - 2023-05-20
 
+- [View Diff](https://github.com/oldmoe/litestack/compare/v0.2.2...v0.2.3)
 - Cut back on options defined in the Litejob Rails adapter
 
 ## [0.2.2] - 2023-05-18
 
+- [View Diff](https://github.com/oldmoe/litestack/compare/v0.2.1...v0.2.2)
 - Fix default queue location in Litejob
 
 
 ## [0.2.1] - 2023-05-08
 
+- [View Diff](https://github.com/oldmoe/litestack/compare/v0.2.0...v0.2.1)
 - Fix a race condition in Litecable
 
 ## [0.2.0] - 2023-05-08
 
+- [View Diff](https://github.com/oldmoe/litestack/compare/v0.1.8...v0.2.0)
 - Litecable, a SQLite driver for ActionCable
 - Litemetric for metrics collection support (experimental, disabled by default)
 - New schema for Litejob, old jobs are auto-migrated
@@ -56,6 +65,7 @@
 
 ## [0.1.8] - 2023-03-08
 
+- [View Diff](https://github.com/oldmoe/litestack/compare/v0.1.7...v0.1.8)
 - More code cleanups, more test coverage
 - Retry support for jobs in Litejob
 - Job storage and garbage collection for failed jobs
@@ -64,6 +74,7 @@
 
 ## [0.1.7] - 2023-03-05
 
+- [View Diff](https://github.com/oldmoe/litestack/compare/v0.1.6...v0.1.7)
 - Code cleanup, removal of references to older name
 - Fix for the litedb rake tasks (thanks: netmute)
 - More fixes for the new concurrency model
@@ -71,6 +82,7 @@
 
 ## [0.1.6] - 2023-03-03
 
+- [View Diff](https://github.com/oldmoe/litestack/compare/v0.1.0...v0.1.6)
 - Revamped the locking model, more robust, minimal performance hit
 - Introduced a new resource pooling class
 - Litecache and Litejob now use the resource pool


### PR DESCRIPTION
Diff links are helpful for visibility into what changed between versions

Pre-Requisite: We need to [create github tags](https://github.com/oldmoe/litestack/tags) for each of the versions releases. This is something that we should be doing anyways (and usually the regular `rake release` task would create a tag)