### PR TITLE
Added server/process crash resiliency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /test/*.sqlite3*
 /production/*.sqlite3*
 .DS_Store
+.idea/

--- a/lib/litestack/litequeue.sql.yml
+++ b/lib/litestack/litequeue.sql.yml
@@ -9,11 +9,20 @@ schema:
         created_at INTEGER DEFAULT(unixepoch()) NOT NULL ON CONFLICT REPLACE
       ) WITHOUT ROWID;
 
+  2:
+    update_table_queue: >
+      ALTER TABLE queue ADD COLUMN worker_id NULL ON CONFLICT REPLACE;
+
+    create_table_workers: >
+      CREATE TABLE IF NOT EXISTS workers(
+        id TEXT PRIMARY KEY NOT NULL ON CONFLICT REPLACE,
+        last_healthy_at INTEGER NOT NULL ON CONFLICT REPLACE
+      ) WITHOUT ROWID;
+
     create_index_queue_by_name: >
       CREATE INDEX IF NOT EXISTS idx_queue_by_name ON queue(name, fire_at ASC);
 
 stmts:
-
   push: >
     INSERT INTO queue(id, name, fire_at, value)
     VALUES (hex(randomblob(32)), $1, (unixepoch() + $2), $3)
@@ -25,14 +34,15 @@ stmts:
     RETURNING name;
 
   pop: >
-    DELETE FROM queue
-    WHERE (name, fire_at, id)
-    IN (
-      SELECT name, fire_at, id FROM queue
-      WHERE name = ifnull($1, 'default')
-        AND fire_at <= (unixepoch())
+    UPDATE queue
+    SET worker_id = $1
+    WHERE id IN (
+      SELECT id FROM queue
+      WHERE name = $2
+      AND fire_at <= unixepoch()
+      AND worker_id IS NULL
       ORDER BY fire_at ASC
-      LIMIT ifnull($2, 1)
+      LIMIT 1
     )
     RETURNING id, value;
 
@@ -51,3 +61,39 @@ stmts:
     FROM queue
     GROUP BY name
     ORDER BY count DESC;
+
+  get_workers: >
+    SELECT id, last_healthy_at
+    FROM workers;
+
+  clear_dead_workers: >
+    DELETE FROM workers
+    WHERE id IN (
+      SELECT id from workers
+      WHERE last_healthy_at < $1
+    )
+    RETURNING id;
+
+  register_worker: >
+    INSERT INTO workers(id, last_healthy_at)
+    VALUES ($1, unixepoch())
+    ON CONFLICT(id) DO UPDATE SET last_healthy_at = unixepoch();
+
+  worker_heartbeat: >
+    UPDATE workers
+    SET last_healthy_at = unixepoch()
+    WHERE id = $1;
+
+  clear_dead_jobs: >
+    DELETE FROM queue
+    WHERE id IN (
+      SELECT id from queue
+      WHERE name = '_dead'
+      LIMIT ifnull($1, 1)
+    )
+    RETURNING id;
+
+  rescue_abandoned_jobs: >
+    UPDATE queue
+    SET worker_id = NULL
+    WHERE worker_id NOT IN (SELECT id FROM workers);

--- a/lib/litestack/litescheduler.rb
+++ b/lib/litestack/litescheduler.rb
@@ -28,6 +28,18 @@ module Litescheduler
     # we should never reach here
   end
 
+  def self.stop(thread)
+    if backend == :threaded || backend == :iodine || backend == :fiber
+      if thread.respond_to?(:kill)
+        thread.kill
+      else
+        thread.raise("Thread stopped")
+      end
+    elsif backend == :polyphony
+      thread.stop
+    end
+  end
+
   def self.storage
     if backend == :fiber || backend == :poylphony
       Fiber.current.storage

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,7 +45,7 @@ def perform_enqueued_jobs(&block)
 
   # iterate over enqueued jobs and perform them
   until $litejobqueue.count.zero?
-    id, serialized_job = $litejobqueue.pop
+    id, serialized_job = $litejobqueue.pop("test_worker")
     next if id.nil?
     $litejobqueue.send(:process_job, "default", id, serialized_job, false)
   end
@@ -58,7 +58,7 @@ def perform_enqueued_job
   # get first enqueued jobs and perform it
   until performed
     attempts += 1
-    id, serialized_job = $litejobqueue.pop
+    id, serialized_job = $litejobqueue.pop("test_worker")
     next if id.nil?
     $litejobqueue.send(:process_job, "default", id, serialized_job, false)
     performed = true

--- a/test/test_queue.rb
+++ b/test/test_queue.rb
@@ -23,21 +23,54 @@ class TestQueue < Minitest::Test
     end
     assert @queue.count == 10
     10.times do
-      @queue.pop
+      @queue.pop("test worker")
     end
-    assert @queue.count == 0
+    assert @queue.pop("test worker").nil?
   end
 
   def test_queues
     @queue.push(1, 0, "def")
-    assert @queue.pop.nil?
-    assert !@queue.pop("def").nil?
+    assert @queue.pop("test worker").nil?
+    assert !@queue.pop("test worker", "def").nil?
   end
 
   def test_delay
     @queue.push(1, 1)
-    assert @queue.pop.nil?
+    assert @queue.pop("test worker").nil?
     sleep 1
-    assert !@queue.pop.nil?
+    assert !@queue.pop("test worker").nil?
+  end
+
+  def test_jobs_assigned_to_workers_can_not_be_popped_twice
+    @queue.push(1, 0)
+    refute @queue.pop("test worker").nil?
+    assert @queue.pop("test worker 2").nil?
+  end
+
+  def test_jobs_assigned_to_dead_workers_are_requeued
+    @queue.push(1, 0)
+    refute @queue.pop("test worker").nil?
+    @queue.rescue_abandoned_jobs
+    refute @queue.pop("test worker").nil?
+  end
+
+  def test_jobs_assigned_to_live_workers_are_not_requeued
+    @queue.push(1, 0)
+    @queue.register_worker("test worker")
+    @queue.pop("test worker")
+    @queue.rescue_abandoned_jobs
+    assert @queue.pop("test worker").nil?
+  end
+
+  def test_dead_workers_are_cleaned_up
+    @queue.register_worker("test worker")
+    @queue.clear_dead_workers(Time.now.to_i + 1)
+    assert @queue.workers.empty?
+  end
+
+  def test_live_workers_are_not_cleaned_up
+    @queue.register_worker("test worker")
+    @queue.clear_dead_workers(Time.now.to_i - 1)
+    refute @queue.workers.empty?
   end
 end


### PR DESCRIPTION
LiteJob is currently lacking crash resiliency. Its mechanism for popping items from the queue deletes the item from the queue table, resulting in a potential lost job if the server/process crashes before the job is completed. 

This PR addresses that issue by:

1. Adding a workers table
2. Associating each queue entry with a worker whenever it is popped and modifying the `pop` logic to ignore queues that have been assigned to a worker
3. Adding a heartbeat for each worker
4. Periodically clearing workers from the workers table who have missed a configurable number of heartbeats
5. Periodically setting the `worker_id` to `NULL` for queues that are referencing workers that no longer exist in the worker table, which will result in reprocessing