### PR TITLE
Register litedb adapter for Rails >= 7.2

### DIFF
--- a/lib/litestack.rb
+++ b/lib/litestack.rb
@@ -19,6 +19,9 @@ require_relative "./active_job/queue_adapters/litejob_adapter" if defined? Activ
 require_relative "./action_cable/subscription_adapter/litecable" if defined? ActionCable
 require_relative "./litestack/railtie" if defined? Rails::Railtie
 
+# register litedb adapter for Rails >= 7.2
+ActiveRecord::ConnectionAdapters.register("litedb", "ActiveRecord::ConnectionAdapters::LitedbAdapter", "active_record/connection_adapters/litedb_adapter") if defined? ActiveRecord && ActiveRecord::ConnectionAdapters.respond_to?(:register)
+
 module Litestack
   class NotImplementedError < RuntimeError; end
 


### PR DESCRIPTION
Rails main branch is failing to find the litedb adapter because some changes introduced here: https://github.com/rails/rails/commit/009c7e74117690f0dbe200188a929b345c9306c1

`Database configuration specifies 'litedb' adapter but that adapter has not been registered. Ensure that the adapter in the Gemfile is at the latest version. If it is, then the adapter may need to be modified. (ActiveRecord::AdapterNotFound)`

This commit registers the adapter. There may be better ways to do it, this is a quick patch to make it work.

Another way is add the new line in an initializer that can be written by the `install` generator.