### PR TITLE
Ensure the liteboard PID file doesn't conflict with Rails

### DIFF
--- a/bin/liteboard
+++ b/bin/liteboard
@@ -15,6 +15,7 @@ options = {
   Port: 9292,
   Host: 'localhost',
   environment: 'production',
+  pid: 'tmp/pids/liteboard.pid',
   quiet: false
 }
 


### PR DESCRIPTION
This allows the user to have a Profile that specifies both the `rails server` command and the `liteboard` commands to spin up both server processes.