### PR TITLE
Use pattern matching in Litescheduler.spawn

### DIFF
--- a/lib/litestack/litescheduler.rb
+++ b/lib/litestack/litescheduler.rb
@@ -18,14 +18,14 @@ module Litescheduler
 
   # spawn a new execution context
   def self.spawn(&block)
-    if backend == :fiber
+    case backend
+    in :fiber
       Fiber.schedule(&block)
-    elsif backend == :polyphony
+    in :polyphony
       spin(&block)
-    elsif (backend == :threaded) || (backend == :iodine)
+    in :threaded | :iodine
       Thread.new(&block)
     end
-    # we should never reach here
   end
 
   def self.storage


### PR DESCRIPTION
Ruby's case/in statements are exhaustive, so they'll raise in case there's an unknown value passed in. So we can upgrade the comment to a guarantee, and save a few conceptual bytes per line.