### PR TITLE
Remove staging environment from cable.yml template

### DIFF
--- a/lib/generators/litestack/install/templates/cable.yml
+++ b/lib/generators/litestack/install/templates/cable.yml
@@ -4,8 +4,5 @@ development:
 test:
   adapter: test
 
-staging:
-  adapter: litecable
-
 production:
   adapter: litecable


### PR DESCRIPTION
Rails apps have 3 environments by default: development, test and production.
Staging is a non-default environment so I think it shouldn't be in the cable.yml template.