### PR TITLE
Add setter for `root` to Litesupport

### DIFF
--- a/lib/generators/litestack/install/install_generator.rb
+++ b/lib/generators/litestack/install/install_generator.rb
@@ -28,8 +28,8 @@ class Litestack::InstallGenerator < Rails::Generators::Base
     append_file ".gitignore", <<~TEXT
 
       # Ignore default Litestack SQLite databases.
-      /db/**/*.sqlite3
-      /db/**/*.sqlite3-*
+      /storage/**/*.sqlite3
+      /storage/**/*.sqlite3-*
     TEXT
   end
 end

--- a/lib/generators/litestack/install/templates/database.yml
+++ b/lib/generators/litestack/install/templates/database.yml
@@ -5,10 +5,10 @@
 #   gem "sqlite3"
 #
 # `Litesupport.root.join("data.sqlite3")` stores
-# application data in the path `./db/#{Rails.env}/data.sqlite3`
+# application data in the path `./storage/#{Rails.env}/data.sqlite3`
 #
 # `Litesupport.root(env).join(path)` stores 
-# application data in the path `./db/#{env}/#{path}`
+# application data in the path `./storage/#{env}/#{path}`
 #
 # idle_timeout should be set to zero, to avoid recycling sqlite connections
 # and losing the page cache
@@ -20,14 +20,14 @@ default: &default
 
 development:
   <<: *default
-  database: <%= Litesupport.root("development").join("data.sqlite3") %>
+  database: <%= Litesupport.root.join("data.sqlite3") %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= Litesupport.root("test").join("data.sqlite3") %>
+  database: <%= Litesupport.root.join("data.sqlite3") %>
 
 # Warning: Make sure your production database path is on a persistent
 # volume, otherwise your application data could be deleted between deploys.
@@ -36,5 +36,5 @@ test:
 # `LITESTACK_DATA_PATH` environment variable.
 production:
   <<: *default
-  database: <%= Litesupport.root("production").join("data.sqlite3") %>
+  database: <%= Litesupport.root.join("data.sqlite3") %>
 

--- a/lib/litestack/litesupport.rb
+++ b/lib/litestack/litesupport.rb
@@ -41,22 +41,27 @@ module Litesupport
     db
   end
 
+  def self.root=(path)
+    @root = Pathname.new(path)
+  end
+
   # Databases will be stored by default at this path.
   def self.root(env = Litesupport.environment)
-    ensure_root_volume detect_root(env)
+    path = (@root || detect_root).join(env)
+    ensure_root_volume(path)
   end
 
   # Default path where we'll store all of the databases.
-  def self.detect_root(env)
+  def self.detect_root
     path = if ENV["LITESTACK_DATA_PATH"]
       ENV["LITESTACK_DATA_PATH"]
     elsif defined? Rails
-      "./db"
+      "./storage"
     else
       "."
     end
 
-    Pathname.new(path).join(env)
+    Pathname.new(path)
   end
 
   def self.ensure_root_volume(path)


### PR DESCRIPTION
This (partially) addresses #34. 

As discussed in that ticket, Rails per default uses `storage` as the location for SQLite DBs, so Litestack's default configuration should adhere to that convention (when using Rails). Furthermore, users should be able to set the location of Litestack's DBs via Ruby if desired.

## Implementation

1. The default location used if Rails is defined has been updated to `storage`. Generator logic has been updated accordingly (e.g. gitignore)
2. A root setter was added to `Litesupport`. This allows setting the Litestack root as desired, e.g. 
  ```ruby
  # initializers/litestack.rb 
  Litesupport.root = './data'
  ```
  Environments will be respected (as in #12), so setting the root as above will result in locations such as `./data/development/data.sqlite3`. I made a slight alteration to the `database.yml` template. Environments are inferred automatically, passing them to `root` is not necessary. 
 
## Known Issues

For some unknown reason ActiveJob initialization and queue definition happens _before_ any initialziers are loaded. So any setting of `litesupport.root` is ignored, with Rails that means `queue.sqlite3` is always created in `storage/{env}/queue.sqlite3`. Works fine for the other DBs however 🤷

I thought the issue might be jobqueue being initialized when Rails loads, but removing the line from Litejob doesn't help:

```ruby
module Litejob
  def self.included(klass)
    klass.extend(ClassMethods)
    klass.get_jobqueue # < Removing this doesn't solve the issue
  end
...
```

@oldmoe @RyanVasichko Maybe #67 could resolve this. In any case, any pointers would be appreciated as I'm quite stuck with this. 

## Follow Ups

As was discussed in #34 it would be neat to configure Litestack mostly via code rather than YMLs. I'd love to improve the current implementation to allow configuration via config objects - that is, after the issue outlined above has been resolved. Something like this reads nice. 
```ruby 
Litestack.configure do |config|
  config.root = './data'
  config.env = 'staging'
end
```
What do you think?