### PR TITLE
Don't start libjobqueue worker unless running under the Server

### DIFF
--- a/lib/litestack/litejobqueue.rb
+++ b/lib/litestack/litejobqueue.rb
@@ -179,6 +179,7 @@ class Litejobqueue < Litequeue
 
   # create a worker according to environment
   def create_worker
+    return if defined?(Rails) && !defined?(Rails::Server)
     Litescheduler.spawn do
       worker_sleep_index = 0
       while @running


### PR DESCRIPTION
In particular, this avoids starting queue workers in the console which leads to ActiveJob emitting log messages into the console, which is confusing and distracting.