### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ idx.search('kamal')
 idx.search('subject: awa') 
 ```
 
-Litesearch integrates tightly with ActiveRecord ans Sequel, here are integration examples
+Litesearch integrates tightly with ActiveRecord and Sequel, here are integration examples
 
 #### ActiveRecord
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ litedb is a wrapper around SQLite3, offering a better default configuration that
 
 #### Direct litedb usage
 
-litedb can be used exactly as the SQLite3 gem, since litedb iherits from SQLite3
+litedb can be used exactly as the SQLite3 gem, since litedb inherits from SQLite3
 
 ```ruby
 require 'litestack'


### PR DESCRIPTION
Fixed 
- one instance of `ans` which should be `and`
- one instance of `iherits` which should be `inherits`

Fixes #90