### PR TITLE
Add conditional check for sqlite3_production_warning before setting to false in railtie.rb

### DIFF
--- a/lib/litestack/railtie.rb
+++ b/lib/litestack/railtie.rb
@@ -3,8 +3,10 @@ require "rails/railtie"
 module Litestack
   class Railtie < ::Rails::Railtie
     initializer :disable_production_sqlite_warning do |app|
-      # The whole point of this gem is to use sqlite3 in production.
-      app.config.active_record.sqlite3_production_warning = false
+      if config.active_record.key?(:sqlite3_production_warning)
+        # The whole point of this gem is to use sqlite3 in production.
+        app.config.active_record.sqlite3_production_warning = false
+      end
     end
   end
 end


### PR DESCRIPTION
As mentioned in https://github.com/oldmoe/litestack/issues/105, the new Rails main (7.2.0-alpha) removes `config.active_record.sqlite3_production_warning` and so the litestack railtie attempt to set it to false fails. This is an attempt to fix that.

This is also a better solution (IMHO) than https://github.com/oldmoe/litestack/pull/98, as there are still people utilizing older versions that might need this check. This only fixes it if it's needed.