### PR TITLE
Add `enqueue_after_transaction_commit` option to Litejob adapter

### DIFF
--- a/lib/active_job/queue_adapters/litejob_adapter.rb
+++ b/lib/active_job/queue_adapters/litejob_adapter.rb
@@ -18,6 +18,10 @@ module ActiveJob
         # Job.options = DEFAULT_OPTIONS.merge(options)
       end
 
+      def enqueue_after_transaction_commit?
+        Job.options[:enqueue_after_transaction_commit]
+      end
+
       def enqueue(job) # :nodoc:
         Job.queue = job.queue_name
         Job.perform_async(job.serialize)
@@ -31,7 +35,8 @@ module ActiveJob
       class Job # :nodoc:
         DEFAULT_OPTIONS = {
           config_path: "./config/litejob.yml",
-          logger: nil # Rails performs its logging already
+          logger: nil, # Rails performs its logging already
+          enqueue_after_transaction_commit: true
         }
 
         include ::Litejob


### PR DESCRIPTION
Following [this change](https://github.com/rails/rails/commit/e922c59207c406d51541622690737783e0ec338e), Litejob adapter should also implement `enqueue_after_transaction_commit`. I noticed that since there's no way to override default options yet, we might as well just set it to true