### PR TITLE
Skip sqlite3 production warning in Rails 7.2

### DIFF
--- a/lib/litestack/railtie.rb
+++ b/lib/litestack/railtie.rb
@@ -2,9 +2,11 @@ require "rails/railtie"
 
 module Litestack
   class Railtie < ::Rails::Railtie
-    initializer :disable_production_sqlite_warning do |app|
-      # The whole point of this gem is to use sqlite3 in production.
-      app.config.active_record.sqlite3_production_warning = false
+    if config.active_record.key?(:sqlite3_production_warning)
+      initializer :disable_production_sqlite_warning do |app|
+        # The whole point of this gem is to use sqlite3 in production.
+        app.config.active_record.sqlite3_production_warning = false
+      end
     end
   end
 end


### PR DESCRIPTION
Sqlite3 Production Warning is being removed: https://github.com/rails/rails/commit/6b446bee63c401364d193920f3426af0bfe75650 