### PR TITLE
fix: make it possible to use litestack in an app not using ActiveRecord

### DIFF
--- a/lib/litestack/railtie.rb
+++ b/lib/litestack/railtie.rb
@@ -3,7 +3,7 @@ require "rails/railtie"
 module Litestack
   class Railtie < ::Rails::Railtie
     initializer :disable_production_sqlite_warning do |app|
-      if config.active_record.key?(:sqlite3_production_warning)
+      if config.respond_to?(:active_record) && config.active_record.key?(:sqlite3_production_warning)
         # The whole point of this gem is to use sqlite3 in production.
         app.config.active_record.sqlite3_production_warning = false
       end


### PR DESCRIPTION
Yes I know this is probably really weird, but I have an app that's not using `ActiveRecord`, and I would like to use `litecache` and `litejob` in it.

I hope you will consider this small change. I'm happy to amend this PR with a test case, but might need some help/guidance on how I could set that up.