### PR TITLE
Improve error debugging in litejob (add backtrace)

### DIFF
--- a/lib/litestack/litejobqueue.rb
+++ b/lib/litestack/litejobqueue.rb
@@ -249,13 +249,13 @@ class Litejobqueue < Litequeue
         # we can retry the failed job now
         capture(:fail, queue)
         if job["retries"] == 0
-          @logger.error "[litejob]:[ERR] queue:#{queue} class:#{job["klass"]} job:#{id} failed with #{e}:#{e.message}, retries exhausted, moved to _dead queue"
+          @logger.error "[litejob]:[ERR] queue:#{queue} class:#{job["klass"]} job:#{id} failed with #{e}:#{e.message}, retries exhausted, moved to _dead queue.\nBacktrace: #{e.backtrace.join("\n")}"
           repush(id, job, @options[:dead_job_retention], "_dead")
         else
           capture(:retry, queue)
           retry_delay = @options[:retry_delay_multiplier].pow(@options[:retries] - job["retries"]) * @options[:retry_delay]
           job["retries"] -= 1
-          @logger.error "[litejob]:[ERR] queue:#{queue} class:#{job["klass"]} job:#{id} failed with #{e}:#{e.message}, retrying in #{retry_delay} seconds"
+          @logger.error "[litejob]:[ERR] queue:#{queue} class:#{job["klass"]} job:#{id} failed with #{e}:#{e.message}, retrying in #{retry_delay} seconds.\nBacktrace: #{e.backtrace.join("\n")}"
           repush(id, job, retry_delay, queue)
         end
       end


### PR DESCRIPTION
Currently, debugging errors in litejob can be challenging due to the lack of detailed information about the root cause of the issues.

I propose adding a backtrace to provide more detailed diagnostics for errors. This will make it easier to trace the source of the problem and simplify the debugging process.

Example of the current error output:
![litestack_compact](https://github.com/user-attachments/assets/f8f9192a-ace1-45a6-afce-4ebdfe79e1be)

Example of the output with backtrace:
![litestack_detail](https://github.com/user-attachments/assets/b4b24d43-4485-441a-bbec-b74233dc3ff3)
