### PR TITLE
Fix: make Railtie compatible with Rails 8 by removing sqlite3_production_warning

### DIFF
--- a/lib/litestack/railtie.rb
+++ b/lib/litestack/railtie.rb
@@ -1,11 +1,33 @@
+# lib/litestack/railtie.rb
 require "rails/railtie"
 
 module Litestack
   class Railtie < ::Rails::Railtie
-    initializer :disable_production_sqlite_warning do |app|
-      if config.active_record.key?(:sqlite3_production_warning)
-        # The whole point of this gem is to use sqlite3 in production.
-        app.config.active_record.sqlite3_production_warning = false
+    # Ensure we run before Active Record reads/apply its configuration
+    initializer :disable_production_sqlite_warning, before: "active_record.set_configs" do |app|
+      ar = app.config.active_record
+
+      # Defensive: some older Rails defaults / templates inject this key
+      # Rails 8 removed the writer, so delete the key entirely on 8+.
+      begin
+        require "active_record"
+        rails8_or_newer =
+          defined?(ActiveRecord::VERSION) &&
+          Gem::Version.new(ActiveRecord::VERSION::STRING) >= Gem::Version.new("8.0.0")
+      rescue LoadError
+        rails8_or_newer = false
+      end
+
+      if rails8_or_newer
+        # On Rails 8+, nuke the unsupported key if present
+        ar.delete(:sqlite3_production_warning) if ar.respond_to?(:delete)
+      else
+        # On Rails 6/7 keep original behavior
+        if ar.respond_to?(:sqlite3_production_warning=)
+          ar.sqlite3_production_warning = false
+        elsif ar.respond_to?(:[]=)
+          ar[:sqlite3_production_warning] = false
+        end
       end
     end
   end

--- a/test/railtie_test.rb
+++ b/test/railtie_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "minitest/autorun"
+
+# Load Rails + AR Railtie so app.config.active_record exists
+require "rails"
+require "active_record/railtie"
+
+# Load the gem under test (ensures Litestack::Railtie is defined)
+require "litestack"
+
+class RailtieTest < Minitest::Test
+  class DummyApp < Rails::Application
+    # Keep noise down during initialize!
+    config.logger = Logger.new(nil)
+    config.eager_load = false
+    config.secret_key_base = "test"
+
+    # Use Rails defaults that match the current AR when changes were made
+    ar_ver = Gem::Version.new(ActiveRecord.version)
+    defaults = ar_ver >= Gem::Version.new("8.0.0") ? "8.0" : "7.1"
+    config.load_defaults defaults
+  end
+
+  def test_litestack_railtie_handles_sqlite3_warning_across_rails_versions
+    # Boot the app — this runs all Railtie initializers including litestack’s
+    DummyApp.initialize!
+
+    keys = DummyApp.config.active_record.respond_to?(:keys) ? DummyApp.config.active_record.keys : []
+
+    if Gem::Version.new(ActiveRecord.version) >= Gem::Version.new("8.0.0")
+      # Rails 8+: key must not be present (writer removed in AR 8)
+      refute_includes keys, :sqlite3_production_warning
+    else
+      # Rails < 8: litestack should still disable the warning
+      assert_equal false, DummyApp.config.active_record[:sqlite3_production_warning]
+    end
+  ensure
+    # Clean up so other tests (if any) can re-init safely
+    Rails.application = nil
+  end
+end


### PR DESCRIPTION
## Summary

This PR fixes a compatibility issue with Rails 8.  
In Rails 8, the `sqlite3_production_warning` configuration key and its writer method (`ActiveRecord::Base.sqlite3_production_warning=`) were removed.  
The current litestack Railtie still sets this flag unconditionally, which causes Rails 8 applications to fail at boot with:

## Changes

- Update `lib/litestack/railtie.rb` initializer:
  - On **Rails < 8**: keep existing behavior (`sqlite3_production_warning = false`).
  - On **Rails ≥ 8**: remove the key from `config.active_record` so ActiveRecord does not attempt to apply it.

## Why

The entire purpose of litestack is to make SQLite production-ready. Disabling the Rails “don’t use SQLite in production” warning is still important for Rails 6/7.  
However, since Rails 8 removed this config entirely, litestack should not attempt to set it anymore.

## Impact

- **Rails 6/7**: behavior unchanged.  
- **Rails 8**: litestack loads without error, and applications can run normally.

## Example

Before this change, Rails 8 apps using litestack crashed during boot.  
After applying this change, the same apps boot cleanly:

```ruby
# Gemfile
gem "litestack", github: "oldmoe/litestack", branch: "rails8-fix"
```

### One more note:
In my app, I had added some debugging in my `config/application.rb` thusly:

```ruby
config.after_initialize do
  keys =
    if config.active_record.respond_to?(:to_h)
      config.active_record.to_h.keys
    elsif config.active_record.respond_to?(:each_pair)
      k = []
      config.active_record.each_pair { |key, _| k << key }
      k
    else
      []
    end
  Rails.logger.warn("AR config keys: #{keys.inspect}")
end
```

With this PR, `sqlite3_production_warning` was not included in the keys in my Rails 8 app.
