### PR TITLE
Fixed small liteboard issue when loading in development mode

### DIFF
--- a/lib/litestack/liteboard/liteboard.rb
+++ b/lib/litestack/liteboard/liteboard.rb
@@ -15,6 +15,8 @@ class Liteboard
     case env["PATH_INFO"]
     when "/"
       Liteboard.new(env).call(:index)
+    when "/favicon.ico"
+      [204, {"cache-control" => "no-cache"}, []]
     when "/topics/Litejob"
       Liteboard.new(env).call(:litejob)
     when "/topics/Litecache"
@@ -23,6 +25,8 @@ class Liteboard
       Liteboard.new(env).call(:litedb)
     when "/topics/Litecable"
       Liteboard.new(env).call(:litecable)
+    else
+      [404, {"content-type" => "text/plain; charset=utf-8", "cache-control" => "no-cache"}, ["Not Found"]]
     end
   end
 
@@ -45,7 +49,7 @@ class Liteboard
   end
 
   def after(body = nil)
-    [200, {"Cache-Control" => "no-cache"}, [body]]
+    [200, {"cache-control" => "no-cache", "content-type" => "text/html; charset=utf-8"}, [body]]
   end
 
   def before


### PR DESCRIPTION
This PR makes Liteboard Rack 3–compliant in development by fixing response headers and default handlers. Minor infra tweak aligned with our ongoing SQLite-first litestack work.

## Changes
- Lowercase response headers to satisfy **Rack 3 Lint** (Cache-Control → cache-control) and add explicit content-type for HTML responses, via Liteboard#after.
- **Driveby:** Add an explicit /favicon.ico route returning 204 No Content to stop repeated browser requests and ensure a valid Rack triplet.
- **Driveby:** Introduce a default 404 handler for unmatched routes so every path returns a proper [status, headers, body] response.
- Net change: 1 deletion, 5 additions in lib/litestack/liteboard/liteboard.rb; commit e33e566 by **@ajitdsa** on **Sep 30, 2025**.

## Testing
- Manual repro documented in commit: run liteboard with development DB and visit “/” and “/favicon.ico”; after change, both routes return valid responses with no Rack::Lint or TempfileReaper errors.
- No automated tests are included in this PR.