### PR TITLE
Fix SQL syntax error when calling .count on LiteSearch results

### DIFF
--- a/test/test_ar_search.rb
+++ b/test/test_ar_search.rb
@@ -1,31 +1,33 @@
-require "minitest/autorun"
+# frozen_string_literal: true
+
+require 'minitest/autorun'
 
 # require_relative "../lib/litestack/litedb"
-require "active_record"
-require "active_record/base"
+require 'active_record'
+require 'active_record/base'
 
-require_relative "patch_ar_adapter_path"
+require_relative 'patch_ar_adapter_path'
 
-require_relative "../lib/active_record/connection_adapters/litedb_adapter"
+require_relative '../lib/active_record/connection_adapters/litedb_adapter'
 
 ActiveRecord::Base.establish_connection(
-  adapter: "litedb",
-  database: ":memory:"
+  adapter: 'litedb',
+  database: ':memory:'
 )
 
 # ActiveRecord::Base.logger = Logger.new(STDOUT)
 
 db = ActiveRecord::Base.connection.raw_connection
-db.execute("CREATE TABLE authors(id INTEGER PRIMARY KEY, name TEXT, created_at TEXT, updated_at TEXT)")
-db.execute("CREATE TABLE publishers(id INTEGER PRIMARY KEY, name TEXT, created_at TEXT, updated_at TEXT)")
-db.execute("CREATE TABLE books(id INTEGER PRIMARY KEY, title TEXT, description TEXT, published_on TEXT, author_id INTEGER, publisher_id INTEGER, state TEXT, created_at TEXT, updated_at TEXT, active INTEGER)")
-db.execute("CREATE TABLE reviews(id INTEGER PRIMARY KEY, book_id INTEGER)")
-db.execute("CREATE TABLE comments(id INTEGER PRIMARY KEY, review_id INTEGER)")
+db.execute('CREATE TABLE authors(id INTEGER PRIMARY KEY, name TEXT, created_at TEXT, updated_at TEXT)')
+db.execute('CREATE TABLE publishers(id INTEGER PRIMARY KEY, name TEXT, created_at TEXT, updated_at TEXT)')
+db.execute('CREATE TABLE books(id INTEGER PRIMARY KEY, title TEXT, description TEXT, published_on TEXT, author_id INTEGER, publisher_id INTEGER, state TEXT, created_at TEXT, updated_at TEXT, active INTEGER)')
+db.execute('CREATE TABLE reviews(id INTEGER PRIMARY KEY, book_id INTEGER)')
+db.execute('CREATE TABLE comments(id INTEGER PRIMARY KEY, review_id INTEGER)')
 # simulate action text
-db.execute("CREATE TABLE rich_texts(id INTEGER PRIMARY KEY, body TEXT, record_id INTEGER, record_type TEXT, created_at TEXT, updated_at TEXT) ")
+db.execute('CREATE TABLE rich_texts(id INTEGER PRIMARY KEY, body TEXT, record_id INTEGER, record_type TEXT, created_at TEXT, updated_at TEXT) ')
 # custom primary and foreing key columns
-db.execute("CREATE TABLE users(user_id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))), name TEXT, created_at TEXT, updated_at TEXT)")
-db.execute("CREATE TABLE posts(post_id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))), author_id TEXT, title TEXT, content TEXT, created_at TEXT, updated_at TEXT)")
+db.execute('CREATE TABLE users(user_id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))), name TEXT, created_at TEXT, updated_at TEXT)')
+db.execute('CREATE TABLE posts(post_id TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))), author_id TEXT, title TEXT, content TEXT, created_at TEXT, updated_at TEXT)')
 
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
@@ -57,12 +59,12 @@ class Book < ApplicationRecord
   include Litesearch::Model
 
   litesearch do |schema|
-    schema.fields [:description, :state]
+    schema.fields %i[description state]
     schema.field :publishing_year, col: :published_on
     schema.field :title, weight: 10
     schema.field :ignored, weight: 0
-    schema.field :author, target: "authors.name"
-    schema.field :publisher, target: "publishers.name", col: :publisher_id
+    schema.field :author, target: 'authors.name'
+    schema.field :publisher, target: 'publishers.name', col: :publisher_id
     schema.filter_column :active
     schema.tokenizer :porter
   end
@@ -72,7 +74,7 @@ class RichText < ApplicationRecord
   belongs_to :record, polymorphic: true
 
   def self.table_name
-    "rich_texts"
+    'rich_texts'
   end
 end
 
@@ -88,7 +90,7 @@ class Review < ApplicationRecord
   include Litesearch::Model
 
   litesearch do |schema|
-    schema.field :body, target: "rich_texts.body", as: :record
+    schema.field :body, target: 'rich_texts.body', as: :record
   end
 end
 
@@ -113,27 +115,27 @@ class Item < ApplicationRecord
 end
 
 class User < ApplicationRecord
-  self.primary_key = "user_id"
+  self.primary_key = 'user_id'
 
   has_many :posts, foreign_key: :author_id
 
   include Litesearch::Model
   litesearch do |schema|
-      schema.fields %w[ name ]
-      schema.primary_key :user_id
+    schema.fields %w[name]
+    schema.primary_key :user_id
   end
 end
 
 class Post < ApplicationRecord
-  self.primary_key = "post_id"
+  self.primary_key = 'post_id'
 
-  belongs_to :author, class_name: "User", primary_key: :user_id
+  belongs_to :author, class_name: 'User', primary_key: :user_id
 
   include Litesearch::Model
   litesearch do |schema|
-      schema.fields %w[ title content ]
-      schema.field :author, target: "users.name", primary_key: :user_id
-      schema.primary_key :post_id
+    schema.fields %w[title content]
+    schema.field :author, target: 'users.name', primary_key: :user_id
+    schema.primary_key :post_id
   end
 end
 
@@ -146,33 +148,37 @@ class TestActiveRecordLitesearch < Minitest::Test
     User.delete_all
     Post.delete_all
     Book.litesearch do |schema|
-      schema.fields [:description, :state]
+      schema.fields %i[description state]
       schema.field :publishing_year, col: :published_on
       schema.field :title, weight: 10
       schema.field :ignored, weight: 0
-      schema.field :author, target: "authors.name"
-      schema.field :publisher, target: "publishers.name", col: :publisher_id
+      schema.field :author, target: 'authors.name'
+      schema.field :publisher, target: 'publishers.name', col: :publisher_id
       schema.filter_column :active
       schema.tokenizer :porter
     end
-    Publisher.create(name: "Penguin")
-    Publisher.create(name: "Adams")
-    Publisher.create(name: "Flashy")
-    Author.create(name: "Hanna Spiegel")
-    Author.create(name: "David Antrop")
-    Author.create(name: "Aly Lotfy")
-    Author.create(name: "Osama Penguin")
-    Book.create(title: "In a middle of a night", description: "A tale of sleep", published_on: "2008-10-01", state: "available", active: true, publisher_id: 1, author_id: 1)
-    Book.create(title: "In a start of a night", description: "A tale of watching TV", published_on: "2006-08-08", state: "available", active: false, publisher_id: 2, author_id: 1)
-    u = User.create(name: "Gabriel")
-    Post.create(author: u, title: "Post #1", content: "Whenever you create a table without specifying the WITHOUT ROWID option, you get an implicit auto-increment column called rowid. The rowid column store 64-bit signed integer that uniquely identifies a row in the table.")
-    Post.create(author: u, title: "Post #2", content: "If a table has the primary key that consists of one column, and that column is defined as INTEGER then this primary key column becomes an alias for the rowid column.")
+    Publisher.create(name: 'Penguin')
+    Publisher.create(name: 'Adams')
+    Publisher.create(name: 'Flashy')
+    Author.create(name: 'Hanna Spiegel')
+    Author.create(name: 'David Antrop')
+    Author.create(name: 'Aly Lotfy')
+    Author.create(name: 'Osama Penguin')
+    Book.create(title: 'In a middle of a night', description: 'A tale of sleep', published_on: '2008-10-01',
+                state: 'available', active: true, publisher_id: 1, author_id: 1)
+    Book.create(title: 'In a start of a night', description: 'A tale of watching TV', published_on: '2006-08-08',
+                state: 'available', active: false, publisher_id: 2, author_id: 1)
+    u = User.create(name: 'Gabriel')
+    Post.create(author: u, title: 'Post #1',
+                content: 'Whenever you create a table without specifying the WITHOUT ROWID option, you get an implicit auto-increment column called rowid. The rowid column store 64-bit signed integer that uniquely identifies a row in the table.')
+    Post.create(author: u, title: 'Post #2',
+                content: 'If a table has the primary key that consists of one column, and that column is defined as INTEGER then this primary key column becomes an alias for the rowid column.')
   end
 
   def test_polymorphic
     review = Review.create(book_id: 1)
-    rt = RichText.create(record: review, body: "a new review")
-    rs = Review.search("review")
+    rt = RichText.create(record: review, body: 'a new review')
+    rs = Review.search('review')
     assert_equal 1, rs.length
     rt.destroy
     review.destroy
@@ -180,10 +186,10 @@ class TestActiveRecordLitesearch < Minitest::Test
 
   def test_rich_text
     review = Review.create(book_id: 1)
-    rt = RichText.create(record: review, body: "a new review")
+    rt = RichText.create(record: review, body: 'a new review')
     comment = Comment.create(review: review)
-    ct = RichText.create(record: comment, body: "a new comment on the review")
-    rs = Comment.search("comment")
+    ct = RichText.create(record: comment, body: 'a new comment on the review')
+    rs = Comment.search('comment')
     assert_equal 1, rs.length
     ct.destroy
     comment.destroy
@@ -192,90 +198,91 @@ class TestActiveRecordLitesearch < Minitest::Test
   end
 
   def test_similar
-    newbook = Book.create(title: "A night", description: "A tale of watching TV", published_on: "2006-08-08", state: "available", active: true, publisher_id: 2, author_id: 2)
+    newbook = Book.create(title: 'A night', description: 'A tale of watching TV', published_on: '2006-08-08',
+                          state: 'available', active: true, publisher_id: 2, author_id: 2)
     book = Book.find 1
     books = book.similar
     assert_equal 1, books.length
-    assert_equal "A night", books.first.title
+    assert_equal 'A night', books.first.title
     newbook.destroy
   end
 
   def test_search
-    rs = Author.search("Hanna")
+    rs = Author.search('Hanna')
     assert_equal 1, rs.length
     assert_equal Author, rs[0].class
   end
 
   def test_search_custom_primary_key
-    rs = User.search("gabriel")
+    rs = User.search('gabriel')
     assert_equal 1, rs.length
     assert_equal User, rs[0].class
   end
 
   def test_search_field
-    rs = Book.search("author: Hanna")
+    rs = Book.search('author: Hanna')
     assert_equal 1, rs.length
     assert_equal Book, rs[0].class
   end
 
   def test_search_field_custom_primary_key
-    rs = Post.search("author: gabriel")
+    rs = Post.search('author: gabriel')
     assert_equal 2, rs.length
     assert_equal true, [Post, Post] - [rs[0].class, rs[1].class] == []
   end
 
   def test_search_all
-    rs = Book.search_all("Hanna", {models: [Author, Book]})
+    rs = Book.search_all('Hanna', { models: [Author, Book] })
     assert_equal 2, rs.length
     assert_equal true, [Author, Book] - [rs[0].class, rs[1].class] == []
   end
 
   def test_search_all_custom_primary_key
-    rs = Post.search_all("gabriel", {models: [Post, User]})
+    rs = Post.search_all('gabriel', { models: [Post, User] })
     assert_equal 3, rs.length
     assert_equal true, [Post, User, Post] - [rs[0].class, rs[1].class, rs[2].class] == []
   end
 
   def test_modify_schema
     Book.litesearch do |schema|
-      schema.fields [:description, :state]
+      schema.fields %i[description state]
       schema.field :publishing_year, col: :published_on
       schema.field :title, weight: 10
       schema.field :ignored, weight: 0
-      schema.field :author, target: "authors.name"
-      schema.field :publisher, target: "publishers.name", col: :publisher_id
+      schema.field :author, target: 'authors.name'
+      schema.field :publisher, target: 'publishers.name', col: :publisher_id
       schema.rebuild_on_modify true
     end
-    rs = Book.search("night tale")
+    rs = Book.search('night tale')
     assert_equal 2, rs.length
     Book.rebuild_index!
-    rs = Book.search("night tale")
+    rs = Book.search('night tale')
     assert_equal 2, rs.length
   end
 
   def test_modify_schema_rebuild_later
     Book.litesearch do |schema|
-      schema.fields [:description, :state]
+      schema.fields %i[description state]
       schema.field :publishing_year, col: :published_on
       schema.field :title, weight: 10
       schema.field :ignored, weight: 0
-      schema.field :author, target: "authors.name"
-      schema.field :publisher, target: "publishers.name", col: :publisher_id
+      schema.field :author, target: 'authors.name'
+      schema.field :publisher, target: 'publishers.name', col: :publisher_id
     end
-    rs = Book.search("night tale")
+    rs = Book.search('night tale')
     assert_equal 1, rs.length
     Book.rebuild_index!
-    rs = Book.search("night tale")
+    rs = Book.search('night tale')
     assert_equal 2, rs.length
   end
 
   def test_update_referenced_column
-    rs = Book.search("Hanna")
+    rs = Book.search('Hanna')
     assert_equal 1, rs.length
-    Author.find(1).update(name: "Hayat")
-    rs = Book.search("Hanna")
+    Author.find(1).update(name: 'Hayat')
+    rs = Book.search('Hanna')
     assert_equal 0, rs.length
-    rs = Book.search("Hayat")
+    rs = Book.search('Hayat')
     assert_equal 1, rs.length
   end
 
@@ -284,20 +291,20 @@ class TestActiveRecordLitesearch < Minitest::Test
       schema.field :name
       schema.rebuild_on_create true
     end
-    rs = Publisher.search("Penguin")
+    rs = Publisher.search('Penguin')
     assert_equal 1, rs.length
   end
 
   def test_uncreated_table
     db = ActiveRecord::Base.connection.raw_connection
-    db.execute("CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT, created_at TEXT, updated_at TEXT)")
-    rs = Item.search("some")
+    db.execute('CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT, created_at TEXT, updated_at TEXT)')
+    rs = Item.search('some')
     assert_equal 0, rs.length
-    Item.create(name: "some item")
-    rs = Item.search("some")
+    Item.create(name: 'some item')
+    rs = Item.search('some')
     assert_equal 1, rs.length
-    Item.create(name: "another item")
-    rs = Item.search("item")
+    Item.create(name: 'another item')
+    rs = Item.search('item')
     assert_equal 2, rs.length
   end
 
@@ -305,5 +312,25 @@ class TestActiveRecordLitesearch < Minitest::Test
     assert_equal false, ActiveRecord::SchemaDumper.ignore_tables.empty?
     # we have created 8 models, one ignore regex for each
     assert_equal 8, ActiveRecord::SchemaDumper.ignore_tables.count
+  end
+
+  def test_search_count
+    # Test that COUNT works on search results (this was previously broken)
+    search_results = Book.search('night')
+    # Only 1 book should be found because the second book has active: false
+    # and the schema has filter_column :active
+    assert_equal 1, search_results.length
+
+    # Test COUNT method on search results
+    count_result = Book.search('night').count
+    assert_equal 1, count_result
+
+    # Test COUNT with different search terms
+    count_result = Book.search('tale').count
+    assert_equal 1, count_result
+
+    # Test COUNT with no results
+    count_result = Book.search('nonexistent').count
+    assert_equal 0, count_result
   end
 end


### PR DESCRIPTION
# This PR fixes a SQL COUNT syntax error in LiteSearch for ActiveRecord relations.

This aligns with our ongoing SQLite-first work using litestack in Rails 8.

## Changes
 • Addressed the ActiveRecord COUNT wrapping issue that produced the near AS syntax error when counting search relations with custom SELECTs. Specifically, the generated SQL looked like SELECT COUNT(channels.*, -channels_search_idx.rank AS search_rank) FROM … which breaks in SQLite.
 • Refactored the search relation construction in lib/litestack/litesearch/model.rb to use a single cohesive SELECT that includes the base table columns plus the negative rank as search_rank, and orders by the index rank. This removes the prior pattern of multiple chained select() calls that confused COUNT.
 • Introduced a custom count override on the returned search relation that performs COUNT via a simpler relation without the complex SELECT list, preserving filters (rank != 0), the MATCH clause, and joins to the FTS-backed index.
 • Kept all existing search semantics intact: ranking, ordering, MATCH behavior, filter_column usage (e.g., active), polymorphic and custom primary key setups, and multi-model search_all behavior.
 • Minor cleanup and consistency pass in tests and code to standardize quoting and schema declarations, while retaining behavior.
 • Added test coverage for COUNT on search relations and verified behavior with filter_column :active and varied search terms.

## Testing
 • Unit tests updated in test/test_ar_search.rb:
 ▫ Verified polymorphic rich text search via Review and Comment models, ensuring MATCH across associated records.
 ▫ Confirmed similar() returns expected related records with proper search_rank handling.
 ▫ Ensured search works across models (Author, Book) and with custom primary keys (User.user_id, Post.post_id).
 ▫ Validated search_all returns multi-model results and respects ordering.
 ▫ Checked rebuild-on-modify and rebuild-later flows for the schema, including tokenizers and filters.
 ▫ Added explicit tests for COUNT on search results:
 ⁃ Book.search(‘night’).count returns 1, respecting active filter.
 ⁃ Varied terms (‘tale’, nonexistent) return correct counts (1 and 0 respectively).
 • No explicit manual testing steps were attached in the PR body; behavior is demonstrated via automated tests.

## Drive-by
I couldn't find contributing guidelines, but in an attempt to leave the campground slightly better than I found it, I ran rubocop on the file that I changed. So most of the changes in the file were rubocop formatting, changing guard clauses, etc. I am marking them in PR comments to help the reviewer.