### PR TITLE
fix 'undefined `extra_pruner`' exception in rescue blocks

### DIFF
--- a/lib/litestack/litecache.rb
+++ b/lib/litestack/litecache.rb
@@ -76,10 +76,8 @@ class Litecache
       run_stmt(:setter, key, value, expires_in)
       capture(:set, key)
     rescue SQLite3::FullException
-      transaction do
-        run_stmt(:extra_pruner, 0.2)
-        run_sql("vacuum")
-      end
+      run_stmt(:extra_pruner, 0.2)
+      run_sql("vacuum")
       retry
     end
     true

--- a/lib/litestack/litecache.rb
+++ b/lib/litestack/litecache.rb
@@ -77,7 +77,7 @@ class Litecache
       capture(:set, key)
     rescue SQLite3::FullException
       transaction do
-        run_stmt(extra_pruner, 0.2)
+        run_stmt(:extra_pruner, 0.2)
         run_sql("vacuum")
       end
       retry
@@ -94,7 +94,7 @@ class Litecache
         run_stmt(:setter, key, v, expires_in)
         capture(:set, key)
       rescue SQLite3::FullException
-        run_stmt(extra_pruner, 0.2)
+        run_stmt(:extra_pruner, 0.2)
         run_sql("vacuum")
         retry
       end


### PR DESCRIPTION
`extra_pruner` is a stored sqlite3 statement, not a ruby variable. this change means the rescue blocks execute the stored statement, rather than try to access a ruby variable that doesn't exist, causing an exception inside the exception handler.