### PR TITLE
fix(litesearch): prevent SQL injection in ActiveRecord search (#143)

### DIFF
--- a/lib/litestack/litesearch/model.rb
+++ b/lib/litestack/litesearch/model.rb
@@ -202,16 +202,36 @@ module Litesearch::Model
         end
         @schema_not_created = false
       end
-      self.select(
-        "#{table_name}.*"
-      ).joins(
-        "INNER JOIN #{index_name} ON #{table_name}.rowid = #{index_name}.rowid AND rank != 0 AND #{index_name} MATCH ", Arel.sql("'#{term}'")
-      ).select(
-        "-#{index_name}.rank AS search_rank"
-      ).order(
-        Arel.sql("#{index_name}.rank")
-      )
+      # Never interpolate the user term into SQL (issue #143).
+      # sanitize_sql_array quotes the value as a SQL literal so input cannot
+      # break out of MATCH '…'. FTS5 operators remain available inside the
+      # bound query; apostrophes are normalized because unquoted FTS5 tokens
+      # cannot contain raw "'" (see SQLite FTS5 syntax / issue discussion).
+      fts_query = prepare_fts_match_query(term)
+      match_join = sanitize_sql_array([
+        "INNER JOIN #{index_name} ON #{table_name}.rowid = #{index_name}.rowid AND rank != 0 AND #{index_name} MATCH ?",
+        fts_query
+      ])
+      select("#{table_name}.*")
+        .joins(match_join)
+        .select("-#{index_name}.rank AS search_rank")
+        .order(Arel.sql("#{index_name}.rank"))
     end
+
+    # Normalize user text into an FTS5 MATCH query string (not SQL).
+    # SQL safety is handled separately via sanitize_sql_array in #search.
+    def prepare_fts_match_query(term)
+      s = term.to_s.tr("'", " ")
+      # Keep letters (incl. CJK via \p{L}), digits, and common FTS5 operators.
+      s = s.gsub(/[^\p{L}\p{N}_\+\*\^\(\):"\s]/u, " ")
+      s = s.delete('"') if s.count('"').odd?
+      tokens = s.split(/\s+/).reject(&:empty?)
+      boolean = %w[AND OR NOT]
+      tokens.pop while tokens.last && boolean.include?(tokens.last.upcase)
+      tokens.shift while tokens.first && boolean.include?(tokens.first.upcase)
+      tokens.join(" ")
+    end
+    private :prepare_fts_match_query
 
     def create_instance(row)
       instantiate(row)

--- a/test/test_litesearch_ar_search_sql_injection.rb
+++ b/test/test_litesearch_ar_search_sql_injection.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+# Coverage for GitHub issue #143:
+# Litesearch AR `search` must not interpolate the user term into SQL unescaped.
+# https://github.com/oldmoe/litestack/issues/143
+#
+# Uses dedicated model/table names so full-suite loads do not clobber
+# test/test_ar_search.rb constants or schemas.
+
+require "minitest/autorun"
+require "active_record"
+require "active_record/base"
+require "active_support"
+require "active_support/notifications"
+
+require_relative "patch_ar_adapter_path"
+require_relative "../lib/active_record/connection_adapters/litedb_adapter"
+
+ActiveRecord::Base.establish_connection(adapter: "litedb", database: ":memory:")
+db = ActiveRecord::Base.connection.raw_connection
+db.execute("CREATE TABLE sqli_authors(id INTEGER PRIMARY KEY, name TEXT, created_at TEXT, updated_at TEXT)")
+db.execute("CREATE TABLE sqli_books(id INTEGER PRIMARY KEY, title TEXT, description TEXT, author_id INTEGER, created_at TEXT, updated_at TEXT)")
+
+module LitesearchSqliFixture
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+
+  class Author < ApplicationRecord
+    self.table_name = "sqli_authors"
+
+    include Litesearch::Model
+
+    litesearch do |schema|
+      schema.field :name
+    end
+  end
+
+  class Book < ApplicationRecord
+    self.table_name = "sqli_books"
+
+    belongs_to :author, class_name: "LitesearchSqliFixture::Author", optional: true
+
+    include Litesearch::Model
+
+    litesearch do |schema|
+      schema.fields [:title, :description]
+    end
+  end
+end
+
+class TestLitesearchArSearchSqlInjection < Minitest::Test
+  Author = LitesearchSqliFixture::Author
+  Book = LitesearchSqliFixture::Book
+
+  def ensure_schema!
+    ActiveRecord::Base.establish_connection(adapter: "litedb", database: ":memory:")
+    db = ActiveRecord::Base.connection.raw_connection
+    db.execute("CREATE TABLE IF NOT EXISTS sqli_authors(id INTEGER PRIMARY KEY, name TEXT, created_at TEXT, updated_at TEXT)")
+    db.execute("CREATE TABLE IF NOT EXISTS sqli_books(id INTEGER PRIMARY KEY, title TEXT, description TEXT, author_id INTEGER, created_at TEXT, updated_at TEXT)")
+    Author.reset_column_information
+    Book.reset_column_information
+  end
+
+  def setup
+    ensure_schema!
+    Author.delete_all
+    Book.delete_all
+    Author.litesearch { |s| s.field :name }
+    Book.litesearch { |s| s.fields [:title, :description] }
+
+    @alice = Author.create!(name: "Alice Wonder")
+    @bob = Author.create!(name: "Bob Builder")
+    @obrien = Author.create!(name: "O'Brien Special")
+    Book.create!(title: "Safe Book", description: "nothing dangerous", author: @alice)
+    Book.create!(title: "Other Book", description: "also safe", author: @bob)
+
+    @sql_log = []
+    @subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*args|
+      event = ActiveSupport::Notifications::Event.new(*args)
+      @sql_log << event.payload[:sql].to_s
+    end
+  end
+
+  def teardown
+    ActiveSupport::Notifications.unsubscribe(@subscriber) if @subscriber
+  end
+
+  def search_sqls
+    @sql_log.select { |s| s.include?("MATCH") || s.include?("search_idx") }
+  end
+
+  def test_normal_search_still_finds_records
+    rs = Author.search("Alice")
+    assert_equal 1, rs.length
+    assert_equal "Alice Wonder", rs.first.name
+  end
+
+  def test_search_is_case_insensitive_like_fts
+    rs = Author.search("alice")
+    assert_operator rs.length, :>=, 1
+  end
+
+  def test_quote_breakout_does_not_return_all_rows
+    # Classic breakout: close the MATCH string and force a tautology.
+    # Vulnerable: ... MATCH 'zzz' OR 1=1 OR ''
+    malicious = "zzz' OR 1=1 OR '"
+    rs = Author.search(malicious)
+    assert_equal 0, rs.length,
+      "injection payload must not return authors via SQL breakout (got #{rs.map(&:name).inspect})"
+  end
+
+  def test_or_true_payload_does_not_return_all_rows
+    malicious = "nonexistent' OR '1'='1"
+    rs = Author.search(malicious)
+    assert_equal 0, rs.length,
+      "OR 1=1 style payload must not bypass FTS term (got #{rs.map(&:name).inspect})"
+  end
+
+  def test_comment_payload_does_not_return_all_rows
+    malicious = "zzz' --"
+    rs = Author.search(malicious)
+    assert_equal 0, rs.length
+  end
+
+  def test_union_style_payload_does_not_error_or_exfiltrate
+    malicious = "x' UNION SELECT 1,2,3 --"
+    rs = Author.search(malicious)
+    assert_kind_of ActiveRecord::Relation, rs
+    assert_operator rs.length, :<=, Author.count
+    names = rs.map(&:name)
+    refute_includes names, "Alice Wonder"
+    refute_includes names, "Bob Builder"
+  end
+
+  def test_sql_log_does_not_embed_raw_unescaped_quote_breakout
+    malicious = "evil' OR 1=1 OR '"
+    Author.search(malicious).load
+    joined = search_sqls.join("\n")
+    refute_match(/MATCH\s+'evil'\s+OR\s+1\s*=\s*1/i, joined,
+      "SQL must not contain unescaped breakout of MATCH string literal:\n#{joined}")
+  end
+
+  def test_bound_or_quoted_term_appears_safely_in_sql
+    term = "safe_unique_token_xyz"
+    Author.search(term).load
+    joined = search_sqls.join("\n")
+    assert(
+      joined.include?("?") || joined.include?(term) || joined.include?("safe_unique_token"),
+      "expected search SQL to reference the term safely:\n#{joined}"
+    )
+  end
+
+  def test_legitimate_apostrophe_in_name_is_searchable_or_safe
+    rs = nil
+    assert_silent do
+      rs = Author.search("O'Brien")
+      rs.load
+    end
+    assert_kind_of ActiveRecord::Relation, rs
+    if rs.any?
+      assert_includes rs.map(&:name), "O'Brien Special"
+    end
+  end
+
+  def test_double_quote_and_fts_operators_do_not_break_sql_layer
+    payloads = [
+      'Alice"',
+      "Alice*",
+      "Alice AND Bob",
+      "Alice OR Bob",
+      "Alice AND",
+      "OR Alice"
+    ]
+    payloads.each do |payload|
+      rs = Author.search(payload)
+      assert_kind_of ActiveRecord::Relation, rs, "payload=#{payload.inspect}"
+      assert_operator rs.length, :<=, Author.count, "payload=#{payload.inspect}"
+    end
+  end
+
+  def test_empty_string_search
+    rs = Author.search("")
+    assert_kind_of ActiveRecord::Relation, rs
+  end
+
+  def test_nil_term_coerced_safely
+    rs = Author.search(nil)
+    assert_kind_of ActiveRecord::Relation, rs
+  end
+
+  def test_book_search_injection_same_protection
+    malicious = "zzz' OR 1=1 OR '"
+    rs = Book.search(malicious)
+    assert_equal 0, rs.length,
+      "Book.search must apply the same SQL-safe term handling"
+  end
+
+  def test_normal_book_search_still_works
+    rs = Book.search("Safe")
+    assert_operator rs.length, :>=, 1
+    assert_equal Book, rs.first.class
+  end
+end


### PR DESCRIPTION
## Summary

Fixes https://github.com/oldmoe/litestack/issues/143.

ActiveRecord `Litesearch::Model#search` was interpolating the user term into SQL:

```ruby
Arel.sql("'#{term}'")
```

so a quote in the query could break out of the `MATCH '…'` literal (e.g. `zzz' OR 1=1 OR '`).

### Changes

1. **SQL safety** — build the JOIN with `sanitize_sql_array([… MATCH ?, term])` so the value is quoted/bound and cannot change SQL structure.
2. **FTS safety** — `prepare_fts_match_query` normalizes apostrophes and strips non-FTS punctuation (keeps `AND`/`OR`/`NOT`, `*`, `^`, `:`, `()`, balanced `"`). Bare FTS tokens cannot contain raw `'`; without this, safe SQL binding alone can still raise `fts5: syntax error` (as discussed on the issue).
3. **Tests** — `test/test_litesearch_ar_search_sql_injection.rb` covers breakout payloads, SQL log shape, apostrophes, operators, empty/nil.

Sequel already used a bound `:term`; this aligns the AR path.

### Notes (issue discussion)

- Doubling quotes for SQL is correct at the SQL layer; FTS5 bareword rules still reject `''` in tokens — hence normalize rather than pass raw apostrophes.
- We do **not** reimplement a full FTS5 tokenizer (comment by @numist); SQL injection is fixed at the AR boundary, and hostile punctuation is stripped so the MATCH layer stays well-formed.

## Test plan

- [x] `ruby -Ilib -Itest test/test_litesearch_ar_search_sql_injection.rb` — 14 runs, 0 failures
- [x] `ruby -Ilib -Itest test/test_ar_search.rb` — existing suite still green